### PR TITLE
fix(css): Prevent page overflow on tall content

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,9 +10,9 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center; /* Centering the content horizontally */
-    justify-content: center; /* Centering the content vertically */
-    height: 100vh;
+    min-height: 100vh;
     text-align: center; /* Centering text */
+    padding: 2rem 1rem;
 }
 
 .title {


### PR DESCRIPTION
This commit fixes a layout issue where the weather card could grow taller than the viewport and have its content cut off.

- The `body` styles in `style.css` have been modified to use `min-height: 100vh` instead of `height: 100vh`.
- The `justify-content: center` property was removed to allow the content to align to the top and scroll naturally.
- This ensures that the page is always at least as tall as the viewport but can expand to accommodate all the weather information, enabling vertical scrolling when necessary.